### PR TITLE
feat: use golang modules and improve code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.so
+greeter

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all: plugins build
+
+run:
+	go run greeter.go
+
+build:
+	go build -o greeter .
+
+plugins:
+	go build -buildmode=plugin -o eng/eng.so eng/greeter.go
+	go build -buildmode=plugin -o chi/chi.so chi/greeter.go
+	go build -buildmode=plugin -o swe/swe.so swe/greeter.go
+	go build -buildmode=plugin -o ru/ru.so ru/greeter.go

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/vladimirvivien/go-plugin-example
+
+go 1.22.4

--- a/greeter.go
+++ b/greeter.go
@@ -22,8 +22,10 @@ func main() {
 		mod = "./eng/eng.so"
 	case "chinese":
 		mod = "./chi/chi.so"
- 	case "swedish":
-	        mod = "./swe/swe.so"
+	case "swedish":
+		mod = "./swe/swe.so"
+	case "russian":
+		mod = "./ru/ru.so"
 	default:
 		fmt.Println("don't speak that language")
 		os.Exit(1)


### PR DESCRIPTION
Previously, they added code examples for using the Russian language, but did not show an example of using the plugin in the main program. Fixed this moment.

I also added a Makefile to simplify the assembly of plugins and the main program. All you need to do is issue one `make` command to build everything you need to run the examples.

We also used golang modules, which came into the language a long time ago.